### PR TITLE
Add additional sample prometheusquerymapping and prometheusserverconfig

### DIFF
--- a/config/samples/metrics_v1alpha1_cassandra.yaml
+++ b/config/samples/metrics_v1alpha1_cassandra.yaml
@@ -1,0 +1,23 @@
+apiVersion: metrics.turbonomic.io/v1alpha1
+kind: PrometheusQueryMapping
+metadata:
+  name: cassandra
+  labels:
+    mapping: cassandra
+spec:
+  entities:
+    - type: application
+      metrics:
+        - type: responseTime
+          queries:
+            - type: used
+              promql: '0.001*max(cassandra_stats{name=~"org:apache:cassandra:metrics:table:(write|read)latency:99thpercentile"}) by (instance)'
+        - type: transaction
+          queries:
+            - type: used
+              promql: 'sum(cassandra_stats{name=~"org:apache:cassandra:metrics:table:(write|read)latency:oneminuterate"}) by (instance)'
+      attributes:
+        - name: ip
+          label: instance
+          matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
+          isIdentifier: true

--- a/config/samples/metrics_v1alpha1_istio.yaml
+++ b/config/samples/metrics_v1alpha1_istio.yaml
@@ -2,6 +2,8 @@ apiVersion: metrics.turbonomic.io/v1alpha1
 kind: PrometheusQueryMapping
 metadata:
   name: istio
+  labels:
+    mapping: istio
 spec:
   entities:
     - type: application

--- a/config/samples/metrics_v1alpha1_jmx-tomcat.yaml
+++ b/config/samples/metrics_v1alpha1_jmx-tomcat.yaml
@@ -2,6 +2,8 @@ apiVersion: metrics.turbonomic.io/v1alpha1
 kind: PrometheusQueryMapping
 metadata:
   name: jmx-tomcat
+  labels:
+    mapping: jmx-tomcat
 spec:
   entities:
     - type: application

--- a/config/samples/metrics_v1alpha1_prometheusserverconfig_emptycluster.yaml
+++ b/config/samples/metrics_v1alpha1_prometheusserverconfig_emptycluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: metrics.turbonomic.io/v1alpha1
+kind: PrometheusServerConfig
+metadata:
+  name: prometheusserverconfig-emptycluster
+spec:
+  address: http://prometheus.istio-system:9090

--- a/config/samples/metrics_v1alpha1_webdriver.yaml
+++ b/config/samples/metrics_v1alpha1_webdriver.yaml
@@ -2,6 +2,8 @@ apiVersion: metrics.turbonomic.io/v1alpha1
 kind: PrometheusQueryMapping
 metadata:
   name: webdriver
+  labels:
+    mapping: webdriver
 spec:
   entities:
     - type: application


### PR DESCRIPTION
This PR:

* Adds a sample prometheus server configuration with empty cluster
* Adds a sample prometheus query mapping for `cassandra` exporter exposed metrics