### PR TITLE
[OM-100450] Update turbo metrics CRD and sample

### DIFF
--- a/api/v1alpha1/cluster_info.go
+++ b/api/v1alpha1/cluster_info.go
@@ -53,11 +53,10 @@ type ClusterIdentifier struct {
 
 	// The unique ID of the cluster.
 	// Get the ID by running the following command inside the cluster:
-	//     kubectl -n default get svc kubernetes -ojsonpath='{.metadata.uid}' | grep -Eo "^[0-9a-fA-F]{8}"
-	// The resulting output should be the first segment of the Kubernetes service ID, which is typically 8
-	// characters long and represented in hexadecimal format.
-	// For example, if the service ID is "5f2bd289-20b8-4c3c-be48-f5c5d8ff9c82", the extracted ID would be "5f2bd289".
-	// +kubebuilder:validation:Pattern:="^[0-9a-fA-F]{8}$"
+	//     kubectl -n default get svc kubernetes -ojsonpath='{.metadata.uid}'
+	// The resulting output should be the Kubernetes service ID, which is a version 4 UUID.
+	// For example, 5f2bd289-20b8-4c3c-be48-f5c5d8ff9c82.
+	// +kubebuilder:validation:Pattern:="^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
 	ID string `json:"id"`
 }
 

--- a/config/crd/bases/metrics.turbonomic.io_prometheusserverconfigs.yaml
+++ b/config/crd/bases/metrics.turbonomic.io_prometheusserverconfigs.yaml
@@ -75,12 +75,9 @@ spec:
                           description: 'The unique ID of the cluster. Get the ID by
                             running the following command inside the cluster: kubectl
                             -n default get svc kubernetes -ojsonpath=''{.metadata.uid}''
-                            | grep -Eo "^[0-9a-fA-F]{8}" The resulting output should
-                            be the first segment of the Kubernetes service ID, which
-                            is typically 8 characters long and represented in hexadecimal
-                            format. For example, if the service ID is "5f2bd289-20b8-4c3c-be48-f5c5d8ff9c82",
-                            the extracted ID would be "5f2bd289".'
-                          pattern: ^[0-9a-fA-F]{8}$
+                            The resulting output should be the Kubernetes service
+                            ID, which is a version 4 UUID. For example, 5f2bd289-20b8-4c3c-be48-f5c5d8ff9c82.'
+                          pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
                           type: string
                       required:
                       - clusterLabels

--- a/config/samples/metrics_v1alpha1_prometheusserverconfig_multicluster.yaml
+++ b/config/samples/metrics_v1alpha1_prometheusserverconfig_multicluster.yaml
@@ -6,7 +6,7 @@ spec:
   address: https://observatorium-api-open-cluster-management-observability.apps.cluster-nbx49.com:9090
   clusters:
     - identifier:
-        id: "5f2bd289"
+        id: "ed531637-064a-473c-a9a8-7970bf27f534"
         clusterLabels:
           cluster: clusterA
       queryMappingSelector:
@@ -16,6 +16,6 @@ spec:
             values:
               - istio
     - identifier:
-        id: "936056e5"
+        id: "cda4d884-a053-4aba-8576-afa5d923e7c6"
         clusterLabels:
           cluster: clusterB


### PR DESCRIPTION
This PR changes the representation of a cluster ID to the full version 4 UUID to avoid potential IP collision.